### PR TITLE
fix: getUserBalance reduce returns a NAN

### DIFF
--- a/src/modules/statements/repositories/StatementsRepository.ts
+++ b/src/modules/statements/repositories/StatementsRepository.ts
@@ -46,9 +46,9 @@ export class StatementsRepository implements IStatementsRepository {
 
     const balance = statement.reduce((acc, operation) => {
       if (operation.type === 'deposit') {
-        return acc + operation.amount;
+        return acc + Number(operation.amount);
       } else {
-        return acc - operation.amount;
+        return acc - Number(operation.amount);
       }
     }, 0)
 


### PR DESCRIPTION
Database registers:
    [amount : 150, type: 'deposit'],
    [amount : 75, type: 'deposit'],
    [amount : 165, type: 'withdraw']

When i have these register on database the reduce of method return a NaN because the typeorm returns string on field amount.
This fix was made to resolve the test case "should be able to show the balance bigger than 0" at the file below.

https://github.com/rianperassoli/ignite-nodejs-challenge-08/blob/134d5825e35a627912a39bca2acbb6d80476b575/src/modules/statements/useCases/getBalance/GetBalanceController.spec.ts