### PR TITLE
fix: balance returning null after second statement

### DIFF
--- a/src/modules/statements/repositories/StatementsRepository.ts
+++ b/src/modules/statements/repositories/StatementsRepository.ts
@@ -46,9 +46,9 @@ export class StatementsRepository implements IStatementsRepository {
 
     const balance = statement.reduce((acc, operation) => {
       if (operation.type === 'deposit') {
-        return acc + operation.amount;
+        return acc + Number(operation.amount);
       } else {
-        return acc - operation.amount;
+        return acc - Number(operation.amount);
       }
     }, 0)
 


### PR DESCRIPTION
In the first statement, the function is returning the correct value, but after the second statement, the balance is returning null. So,  when making a withdraw, the use case can't check if amount is grater than balance, and is making the withdraw even if balance is lower than the amount.

I just forced the operation amount value to be a number during reduce calculation.